### PR TITLE
Get merchants items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,10 +32,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'
-  gem 'rspec-rails'
-  gem 'simplecov'
   gem 'faker'
-  gem 'pry'
 end
 
 group :development do
@@ -49,6 +46,7 @@ group :test do
   gem 'pry'
   gem 'simplecov'
   gem 'rspec-rails'
+  gem 'shoulda-matchers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.22.0)
+    faker (2.23.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -139,6 +139,8 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
     ruby_dep (1.5.0)
+    shoulda-matchers (5.1.0)
+      activesupport (>= 5.2.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -178,6 +180,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.8, >= 5.2.8.1)
   rspec-rails
+  shoulda-matchers
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/api/v1/merchant_items_controller.rb
+++ b/app/controllers/api/v1/merchant_items_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::MerchantItemsController < ApplicationController
+  def index
+    merchant = Merchant.find(params[:merchant_id]) #First we need to identify a merchant
+    render json: ItemSerializer.format_items(merchant.items) #At the model level, a Merchant has_many Items
+  end
+end

--- a/app/controllers/api/v1/merchant_items_controller.rb
+++ b/app/controllers/api/v1/merchant_items_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::MerchantItemsController < ApplicationController
   def index
-    merchant = Merchant.find(params[:merchant_id]) #First we need to identify a merchant
-    render json: ItemSerializer.format_items(merchant.items) #At the model level, a Merchant has_many Items
+    if Item.exists?(merchant_id: params[:merchant_id])
+      merchant = Merchant.find(params[:merchant_id]) #First we need to identify a merchant
+      render json: ItemSerializer.format_items(merchant.items) #At the model level, a Merchant has_many Items
+    else
+      render json: {error: "Not Found"}, status: 404
+    end
   end
 end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -4,6 +4,10 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def show
-    render json: MerchantSerializer.format_merchant(Merchant.find(params[:id]))
+    if Merchant.exists?(params[:id])
+      render json: MerchantSerializer.format_merchant(Merchant.find(params[:id]))
+    else
+      render json: {error: "Not Found"}, status: 404      
+    end
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,3 @@
+class Item < ApplicationRecord
+  belongs_to :merchant
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,2 +1,3 @@
 class Merchant < ApplicationRecord
+  has_many :items
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,18 @@
+class ItemSerializer
+  def self.format_items(items)
+    {
+      data: items.map do |item|
+        {
+          id: item.id.to_s,
+          type: 'item',
+          attributes: {
+            name: item.name,
+            description: item.description,
+            unit_price: item.unit_price,
+            merchant_id: item.merchant_id
+          }
+        }
+      end
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :merchants, only: [:index, :show]
+      resources :merchants, only: [:index, :show] do
+        resources :items, only: [:index], controller: :merchant_items
+      end
     end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :item do
+    name { Faker::Games::Zelda.item }
+    description { Faker::Movies::HitchhikersGuideToTheGalaxy.quote }
+    unit_price { Faker::Number.decimal(l_digits: 2) }
+    merchant { Faker::Number.between(1, 9) }
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  describe 'relationships' do
+    it { should belong_to :merchant }
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Merchant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'relationships' do
+    it { should have_many :items }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,3 +68,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/api/v1/merchant_items_request_spec.rb
+++ b/spec/requests/api/v1/merchant_items_request_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Items Request API' do
+  it 'sends all items that belong to a merchant' do
+    id = create(:merchant).id
+    create_list(:item, 5, merchant_id: id)
+
+    get "/api/v1/merchants/#{id}/items/"
+
+    response_data = JSON.parse(response.body, symbolize_names: true)
+    items = response_data[:data]
+    
+    expect(items.count).to eq(5)
+
+    items.each do |item|
+      expect(item).to have_key(:id)
+      expect(item).to have_key(:type)
+      expect(item).to have_key(:attributes)
+      
+      expect(item[:id]).to be_a(String)
+      expect(item[:type]).to be_a(String)
+      expect(item[:attributes]).to be_a(Hash)
+      
+      expect(item[:attributes]).to have_key(:name)
+      expect(item[:attributes]).to have_key(:unit_price)
+      expect(item[:attributes]).to have_key(:description)
+      expect(item[:attributes]).to have_key(:merchant_id)
+
+      expect(item[:attributes][:name]).to be_a(String)
+      expect(item[:attributes][:unit_price]).to be_a(Float)
+      expect(item[:attributes][:description]).to be_a(String)
+      expect(item[:attributes][:merchant_id]).to be_a(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v1/merchant_items_request_spec.rb
+++ b/spec/requests/api/v1/merchant_items_request_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe 'Merchant Items Request API' do
       expect(item[:attributes][:merchant_id]).to be_a(Integer)
     end
   end
+
+  it 'returns 404 if merchant items not found' do
+    get "/api/v1/merchants/42/items"
+    expect(response.message).to eq("Not Found")
+    expect(response.status).to eq(404)
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API' do
+RSpec.describe 'Merchants API' do
   it 'sends a list of merchants' do
     create_list(:merchant, 7)
 
@@ -18,6 +18,9 @@ describe 'Merchants API' do
 
       expect(merchant[:attributes]).to have_key(:name)
       expect(merchant[:attributes][:name]).to be_a(String)
+      
+      expect(merchant[:attributes]).to_not have_key(:created_at)
+      expect(merchant[:attributes]).to_not have_key(:updated_at)
     end
   end
 
@@ -35,8 +38,16 @@ describe 'Merchants API' do
     expect(merchant).to have_key(:id)
     expect(merchant[:id]).to be_an(String)
 
+    expect(merchant[:type]).to eq("merchant")
+
     expect(merchant[:attributes]).to have_key(:name)
     expect(merchant[:attributes][:name]).to be_a(String)
     expect(merchant[:attributes][:name]).to eq(merchant[:attributes].values[0])
+  end
+
+  it 'returns 404 if merchant not found' do
+    get "/api/v1/merchants/42"
+    expect(response.message).to eq("Not Found")
+    expect(response.status).to eq(404)
   end
 end


### PR DESCRIPTION
**Get a Merchant's Items**, Resolves #3

**Introduces:**
- Add Test: Sends all items that belong to a merchant
- Add: Item factory with faker attributes
- Add Test: Merchant and item model relationships
- Add: Shoulda matchers gem
- Add Feature: Merchant and item model with relationships
- Add: Merchant items index route
- Add Feature: Merchant items controller index
- Add Feature: Item serializer customizes items list format

**Fixes:**
- Add Refactor: Sad path status 404 to merchant item request spec
- Add Refactor: Sad path feature, returns 404 in merchant items controller
- Add Refactor: Sad path, returns 404 in merchant request spec
- Add Refactor: Sad path feature, returns 404 in merchants controller show

<br>

**Testing Changes:**

   - [ ] No Tests have been changed
   - [x] Some Tests have been changed. Please describe which ones: Single merchant test has been modified to add 404 error sad path.
   - [ ] All of the Tests have been changed. Please describe what in the world happened:
  
<br>

**Testing Functionality:**
   - [x] All Tests are Passing
   - [ ] Some Tests are not passing. Please describe which ones:
   - [x] All Postman Tests are Passing
   - [ ] Some Postman Tests produce errors. Please describe which ones:
   - [x] Coverage report generated. Please report RSpec coverage: 144 / 144 LOC (100.0%) covered.

<br>

**Feature Functionality:**
   - [x] The code will run locally
   - [ ] The code will not run locally. Please describe what features:
   - [ ] The code will run on Heroku
   - [x] The code will not run on Heroku. Please describe what features: All - exposing APIs, no views needed.

